### PR TITLE
Quick fix scoring 'dont know' selections as 0

### DIFF
--- a/source/questions.html.erb
+++ b/source/questions.html.erb
@@ -28,10 +28,10 @@ title: Co-op Communities - Assemble
           </label>
           <div class="indented" aria-hidden="false">
             <label class="block-label">
-                <input type="radio" value="doesnt-apply" name="<%=question.title%>-reason-dont-know">Doesn't apply
+                <input type="radio" value="0" name="<%=question.title%>-reason-dont-know">Doesn't apply
             </label>
             <label class="block-label">
-                <input type="radio" value="dont-understand" name="<%=question.title%>-reason-dont-know">Don't understand
+                <input type="radio" value="0" name="<%=question.title%>-reason-dont-know">Don't understand
             </label>
           </div>
         </section>


### PR DESCRIPTION
This is a quick fix, since if the user selects 'Don't know/Doesn't
apply' as an answer it means the average score for this dimension
isn't calculated.

This happens because you can't average a mixture of strings and
numbers.

To fix this, I've simply suggested 'Don't know's' now are recorded
as zero.